### PR TITLE
Fix checklist state sync and new block focus

### DIFF
--- a/src/components/Editor.jsx
+++ b/src/components/Editor.jsx
@@ -57,6 +57,10 @@ const Block = ({ block, onUpdate, onDelete, onEnter, onTypeChange }) => {
     setContent(block.content);
   }, [block.content]);
 
+  useEffect(() => {
+    setChecked(block.checked || false);
+  }, [block.checked]);
+
   // Auto-save after typing stops
   useEffect(() => {
     const timer = setTimeout(() => {
@@ -338,8 +342,10 @@ export default function Editor() {
     
     // Focus on the new block
     setTimeout(() => {
-      const textarea = document.querySelector(`[data-block-id="${blockId}"] textarea`);
-      textarea?.focus();
+      const contentEditable = document.querySelector(
+        `[data-block-id="${blockId}"] [contenteditable="true"]`
+      );
+      contentEditable?.focus();
     }, 100);
   };
 


### PR DESCRIPTION
## Summary
- keep checklist blocks in sync with stored checked values
- focus the correct contenteditable element after inserting a new block

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68de26018b3c8327ba11027ffcfba59b